### PR TITLE
Publish it on PyPI

### DIFF
--- a/noteshrink.py
+++ b/noteshrink.py
@@ -577,6 +577,9 @@ def notescan_main(options):
 
 ######################################################################
 
-if __name__ == '__main__':
-
+def main():
+    '''Parse args and call notescan_main().'''
     notescan_main(options=get_argument_parser().parse_args())
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import os
+import sys
+from setuptools import setup
+
+if sys.argv[-1] == "publish":
+    if os.system("pip3 freeze | grep wheel"):
+        print("wheel not installed.\nUse `pip install wheel`.\nExiting.")
+        sys.exit()
+    os.system("python3 setup.py sdist upload")
+    os.system("python3 setup.py bdist_wheel upload")
+    print("You probably want to also tag the version now:")
+    print("  git tag -a VERSION -m 'version VERSION'")
+    print("  git push --tags")
+    sys.exit()
+
+setup(
+    name="noteshrink",
+    version="0.1.0",
+    author="Matt Zucker",
+    description="Convert scans of handwritten notes to beautiful, compact PDFs",
+    url="https://github.com/mzucker/noteshrink",
+    py_modules=["noteshrink"],
+    install_requires=[
+        "numpy",
+        "scipy",
+        "pillow",
+    ],
+    entry_points="""
+        [console_scripts]
+        noteshrink=noteshrink:main
+    """,
+)


### PR DESCRIPTION
This way it would be easier for users to install your program (i. e. `pip install noteshrink`). I've added the setup.py (in this PR), so you'd just have to run `python setup.py register` (it would ask to authorize on [PyPI](http://pypi.python.org/) the first time you run it) and `python setup.py publish`.