### PR TITLE
Explicitly convert palette to bytes

### DIFF
--- a/noteshrink.py
+++ b/noteshrink.py
@@ -452,7 +452,7 @@ the background color to pure white.
         palette[0] = (255, 255, 255)
 
     output_img = Image.fromarray(labels, 'P')
-    output_img.putpalette(palette.flatten())
+    output_img.putpalette(palette.flatten().tobytes())
     output_img.save(output_filename, dpi=dpi)
 
 ######################################################################


### PR DESCRIPTION
PIllow in function putpalette() tries to convert palette to bytes and fails. This patch converts palette to bytes before passing it to putpalette().
Tested with Python 3.6.
Solves issue #17 