### PR TITLE
Describe ImageMagick install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,16 @@ Convert scans of handwritten notes to beautiful, compact PDFs -- see full writeu
 ## Requirements
 
  - Python 2 or 3
+
+Python libraries: (use requirements.txt)
  - NumPy 1.10 or later
  - SciPy
- - ImageMagick
  - Image module from PIL or Pillow
+
+Also:
+ - ImageMagick (for "convert")
+   - on macOS: `brew install imagemagick` (requires Homebrew)
+   - on Debian/Ubuntu: `sudo apt-get install imagemagick`
 
 ## Usage
 
@@ -26,7 +32,7 @@ make
 ## Packages
 Packages are available for:
  - [Arch Linux (AUR)](https://aur.archlinux.org/packages/noteshrink/)
- 
+
 ## Derived works
 
 *Note:* Projects listed here aren't necessarily tested or endorsed by me -- use with care!


### PR DESCRIPTION
Fixes #22 

It wasn't clear to me you had to install ImageMagick. It was listed with the other python requirements, so I assumed that was all covered.

In addition I googled around for this mysterious "convert" program and couldn't find it, with such a generic name. So this change in the docs will probably help someone after me.