### PR TITLE
Added Noteshrink Docker Image link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,4 @@ Packages are available for:
 *Note:* Projects listed here aren't necessarily tested or endorsed by me -- use with care!
 
   - [Web-based (Django) front-end](https://github.com/delneg/noteshrinker-django)
+  - [Noteshrink Docker Image](https://hub.docker.com/r/johnpaulada/noteshrink/)


### PR DESCRIPTION
I created a [Noteshrink Docker image](https://hub.docker.com/r/johnpaulada/noteshrink/) because I don't want to install ImageMagick and the other stuff on my machine. I added it to the derived projects list.