### PR TITLE
Denoise

### DIFF
--- a/noteshrink.py
+++ b/noteshrink.py
@@ -243,7 +243,7 @@ def get_argument_parser():
                         help='background value threshold %%'+show_default)
 
     parser.add_argument('-s', dest='sat_threshold', metavar='PERCENT',
-                        type=percent, default='20',
+                        type=percent, default='15',
                         help='background saturation '
                         'threshold %%'+show_default)
 

--- a/noteshrink.py
+++ b/noteshrink.py
@@ -16,7 +16,7 @@ import re
 import subprocess
 import shlex
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 
 import numpy as np
 from PIL import Image
@@ -221,9 +221,8 @@ def get_argument_parser():
     """
 
     parser = ArgumentParser(
+        formatter_class=ArgumentDefaultsHelpFormatter,
         description='convert scanned, hand-written notes to PDF')
-
-    show_default = ' (default %(default)s)'
 
     parser.add_argument('filenames', metavar='IMAGE', nargs='+',
                         help='files to convert')
@@ -234,29 +233,29 @@ def get_argument_parser():
 
     parser.add_argument('-b', dest='basename', metavar='BASENAME',
                         default='page',
-                        help='output PNG filename base' + show_default)
+                        help='output PNG filename base')
 
     parser.add_argument('-o', dest='pdfname', metavar='PDF',
                         default='output.pdf',
-                        help='output PDF filename' + show_default)
+                        help='output PDF filename')
 
     parser.add_argument('-v', dest='value_threshold', metavar='PERCENT',
                         type=percent, default='25',
-                        help='background value threshold %%'+show_default)
+                        help='background value threshold %%')
 
     parser.add_argument('-s', dest='sat_threshold', metavar='PERCENT',
                         type=percent, default='15',
                         help='background saturation '
-                        'threshold %%'+show_default)
+                        'threshold %%')
 
     parser.add_argument('-n', dest='num_colors', type=int,
                         default='8',
-                        help='number of output colors '+show_default)
+                        help='number of output colors')
 
     parser.add_argument('-p', dest='sample_fraction',
                         metavar='PERCENT',
                         type=percent, default='5',
-                        help='%% of pixels to sample' + show_default)
+                        help='%% of pixels to sample')
 
     parser.add_argument('-w', dest='white_bg', action='store_true',
                         default=False, help='make background white')


### PR DESCRIPTION
Added two denoising methods. [Median filtering](https://en.wikipedia.org/wiki/Median_filter) and [opening](https://en.wikipedia.org/wiki/Opening_(morphology)) of the binary background mask.

Baseline
![Baseline](https://github.com/mzucker/noteshrink/assets/7861774/de38b697-2958-44a9-af50-1e6504288e8d)
![image](https://github.com/mzucker/noteshrink/assets/7861774/6b704d40-fcba-44c6-975e-bc5dd52e61c7)


Median filtering
![median](https://github.com/mzucker/noteshrink/assets/7861774/e65f8d1c-e4da-4077-a972-db96edd9f05f)
![image](https://github.com/mzucker/noteshrink/assets/7861774/87d452fc-d691-4980-b34f-f1e54e7dab0e)


Opening
![opening](https://github.com/mzucker/noteshrink/assets/7861774/18fde009-6129-4e51-8990-8af893f2d828)
![image](https://github.com/mzucker/noteshrink/assets/7861774/4ece9b43-fc36-4f65-a015-271425cf10c2)

Opening works really nice and reliable on removing background noice / speckles but does not work on color surfaces other than background and causes problems with very fine lines.
Median filtering works slightly less well in reducing background noise but takes the complete picture into consideration and works better on fine lines.